### PR TITLE
fix: パッケージのバージョンを変更

### DIFF
--- a/vue-svg/package.json
+++ b/vue-svg/package.json
@@ -12,8 +12,8 @@
     "vue": "^2.6.10"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.9.3",
-    "@vue/cli-plugin-eslint": "^3.9.3",
+    "@vue/cli-plugin-babel": "^3.9.2",
+    "@vue/cli-plugin-eslint": "^3.9.2",
     "@vue/cli-service": "^3.9.3",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.16.0",


### PR DESCRIPTION
今回変更した2つのモジュールの最新バージョンが両方とも `3.9.2` でした。

https://www.npmjs.com/package/@vue/cli-plugin-babel
https://www.npmjs.com/package/@vue/cli-plugin-eslint